### PR TITLE
Add `unsafe-inline` and `blob:` sources to Content Security Policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
 [[headers]]
   for = "/*"
 [headers.values]
-  Content-Security-Policy = "default-src https: blob: 'unsafe-inline' 'unsafe-eval'"
+  Content-Security-Policy = "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'"
   X-Frame-Options = "DENY"
   X-XSS-Protection = "1; mode=block"
   X-Content-Type-Options = "nosniff"

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
 [[headers]]
   for = "/*"
 [headers.values]
-  Content-Security-Policy = "default-src https: blob: 'unsafe-inline'"
+  Content-Security-Policy = "default-src https: blob: 'unsafe-inline' 'unsafe-eval'"
   X-Frame-Options = "DENY"
   X-XSS-Protection = "1; mode=block"
   X-Content-Type-Options = "nosniff"

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,9 +21,8 @@
 [[headers]]
   for = "/*"
 [headers.values]
-  Content-Security-Policy = "default-src https:"
+  Content-Security-Policy = "default-src https: blob: 'unsafe-inline'"
   X-Frame-Options = "DENY"
   X-XSS-Protection = "1; mode=block"
   X-Content-Type-Options = "nosniff"
   Referrer-Policy = "no-referrer"
-


### PR DESCRIPTION
## Overview

Add `unsafe-inline` and `blob:` sources to Content Security Policy.

Fixes #4 

## Testing Instructions

See deploy preview in PR checks.